### PR TITLE
Performance of `(+,-,*,/)(::TaylorScalar,::Number)`: easy short path ? 

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,7 @@
 			]
 		}
 	},
-	"postCreateCommand": "julia -e 'using Pkg; Pkg.add([\"Revise\", \"TestEnv\"])'",
+	"postCreateCommand": "julia -e 'using Pkg; Pkg.add([\"Revise\", \"TestEnv\", \"JuliaFormatter\", \"Cthulhu\"])'",
 	"hostRequirements": {
 		"cpus": 4
 	}

--- a/benchmark/Manifest.toml
+++ b/benchmark/Manifest.toml
@@ -1,6 +1,6 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.8.5"
+julia_version = "1.8.4"
 manifest_format = "2.0"
 project_hash = "141466748547092db2659f061bcf16b16bf160f5"
 

--- a/src/primitive.jl
+++ b/src/primitive.jl
@@ -106,6 +106,8 @@ end
     ex = :($ex; TaylorScalar($([Symbol('v', i) for i in 1:N]...)))
     return :(@inbounds $ex)
 end
+@inline *(a::TaylorScalar{T1, N}, b::TaylorScalar{T2, N}) where {T1,T2,N} = *(promote(a,b)...)
+@inline /(a::TaylorScalar{T1, N}, b::TaylorScalar{T2, N}) where {T1,T2,N} = *(promote(a,b)...)
 
 @generated function ^(t::TaylorScalar{T, N}, n::S) where {S <: Number, T, N}
     ex = quote

--- a/src/scalar.jl
+++ b/src/scalar.jl
@@ -1,5 +1,3 @@
-import Base: zero, one, adjoint, conj, transpose
-import Base: +, -, *, /
 import Base: convert, promote_rule
 
 export TaylorScalar
@@ -60,20 +58,13 @@ end
 @inline extract_derivative(r, i::Integer) = false
 @inline primal(t::TaylorScalar) = extract_derivative(t, 1)
 
-@inline zero(::Type{TaylorScalar{T, N}}) where {T, N} = TaylorScalar{T, N}(zero(T))
-@inline one(::Type{TaylorScalar{T, N}}) where {T, N} = TaylorScalar{T, N}(one(T))
-@inline zero(::TaylorScalar{T, N}) where {T, N} = zero(TaylorScalar{T, N})
-@inline one(::TaylorScalar{T, N}) where {T, N} = one(TaylorScalar{T, N})
-
-adjoint(t::TaylorScalar) = t
-conj(t::TaylorScalar) = t
-
 function promote_rule(::Type{TaylorScalar{T, N}},
                       ::Type{S}) where {T, S, N}
     TaylorScalar{promote_type(T, S), N}
 end
-function promote_rule(::Type{TaylorScalar{T1, N}}, ::Type{TaylorScalar{T2,N}}) where {T1, T2, N}
-TaylorScalar{promote_type(T1,T2), N}
+function promote_rule(::Type{TaylorScalar{T1, N}},
+                      ::Type{TaylorScalar{T2, N}}) where {T1, T2, N}
+    TaylorScalar{promote_type(T1, T2), N}
 end
 
 # Number-like convention (I patched them after removing <: Number)
@@ -82,17 +73,6 @@ convert(::Type{TaylorScalar{T, N}}, x::TaylorScalar{T, N}) where {T, N} = x
 function convert(::Type{TaylorScalar{T, N}}, x::S) where {T, S, N}
     TaylorScalar{T, N}(convert(T, x))
 end
-function convert(::Type{TaylorScalar{T1,N}},x::TaylorScalar{T2,N}) where {T1,T2,N}
-    TaylorScalar{T1,N}(convert.(T1,value(x)))
+function convert(::Type{TaylorScalar{T1, N}}, x::TaylorScalar{T2, N}) where {T1, T2, N}
+    TaylorScalar{T1, N}(convert.(T1, value(x)))
 end
-@inline +(a::Number, b::TaylorScalar) = TaylorScalar((a + value(b)[1]), value(b)[2:end]...)
-@inline -(a::Number, b::TaylorScalar) = TaylorScalar((a - value(b)[1]), .-value(b)[2:end]...)
-@inline *(a::Number, b::TaylorScalar) = TaylorScalar((a .* value(b))...)
-@inline /(a::Number, b::TaylorScalar) = /(promote(a, b)...)
-
-@inline +(a::TaylorScalar, b::Number) = TaylorScalar((value(a)[1] + b), value(a)[2:end]...)
-@inline -(a::TaylorScalar, b::Number) = TaylorScalar((value(a)[1] - b), value(a)[2:end]...)
-@inline *(a::TaylorScalar, b::Number) = TaylorScalar((value(a) .* b)...)
-@inline /(a::TaylorScalar, b::Number) = TaylorScalar((value(a) ./ b)...)
-
-transpose(t::TaylorScalar) = t

--- a/src/scalar.jl
+++ b/src/scalar.jl
@@ -79,8 +79,14 @@ convert(::Type{TaylorScalar{T, N}}, x::TaylorScalar{T, N}) where {T, N} = x
 function convert(::Type{TaylorScalar{T, N}}, x::S) where {T, S, N}
     TaylorScalar{T, N}(convert(T, x))
 end
-for op in (:+, :-, :*, :/)
-    @eval @inline $op(a::TaylorScalar, b::Number) = $op(promote(a, b)...)
-    @eval @inline $op(a::Number, b::TaylorScalar) = $op(promote(a, b)...)
-end
+@inline +(a::Number, b::TaylorScalar) = TaylorScalar((a + value(b)[1]), value(b)[2:end]...)
+@inline -(a::Number, b::TaylorScalar) = TaylorScalar((a - value(b)[1]), .-value(b)[2:end]...)
+@inline *(a::Number, b::TaylorScalar) = TaylorScalar((a .* value(b))...)
+@inline /(a::Number, b::TaylorScalar) = /(promote(a, b)...)
+
+@inline +(a::TaylorScalar, b::Number) = TaylorScalar((value(a)[1] + b), value(a)[2:end]...)
+@inline -(a::TaylorScalar, b::Number) = TaylorScalar((value(a)[1] - b), value(a)[2:end]...)
+@inline *(a::TaylorScalar, b::Number) = TaylorScalar((value(a) .* b)...)
+@inline /(a::TaylorScalar, b::Number) = TaylorScalar((value(a) ./ b)...)
+
 transpose(t::TaylorScalar) = t

--- a/src/scalar.jl
+++ b/src/scalar.jl
@@ -72,12 +72,18 @@ function promote_rule(::Type{TaylorScalar{T, N}},
                       ::Type{S}) where {T, S, N}
     TaylorScalar{promote_type(T, S), N}
 end
+function promote_rule(::Type{TaylorScalar{T1, N}}, ::Type{TaylorScalar{T2,N}}) where {T1, T2, N}
+TaylorScalar{promote_type(T1,T2), N}
+end
 
 # Number-like convention (I patched them after removing <: Number)
 
 convert(::Type{TaylorScalar{T, N}}, x::TaylorScalar{T, N}) where {T, N} = x
 function convert(::Type{TaylorScalar{T, N}}, x::S) where {T, S, N}
     TaylorScalar{T, N}(convert(T, x))
+end
+function convert(::Type{TaylorScalar{T1,N}},x::TaylorScalar{T2,N}) where {T1,T2,N}
+    TaylorScalar{T1,N}(convert.(T1,value(x)))
 end
 @inline +(a::Number, b::TaylorScalar) = TaylorScalar((a + value(b)[1]), value(b)[2:end]...)
 @inline -(a::Number, b::TaylorScalar) = TaylorScalar((a - value(b)[1]), .-value(b)[2:end]...)


### PR DESCRIPTION
Hey, 

The current implementation of `*(::TaylorScalar,::Number)` in your package promotes the scalar to a TaylorScalar as so : 

````julia
for op in (:+, :-, :*, :/)
    @eval @inline $op(a::TaylorScalar, b::Number) = $op(promote(a, b)...)
    @eval @inline $op(a::Number, b::TaylorScalar) = $op(promote(a, b)...)
end
````
and then uses the full blown multiplication of taylorScalars: 
````julia
@generated function *(a::TaylorScalar{T, N}, b::TaylorScalar{T, N}) where {T, N}
    return quote
        va, vb = value(a), value(b)
        @inbounds TaylorScalar($([:(+($([:($(binomial(i - 1, j - 1)) * va[$j] *
                                           vb[$(i + 1 - j)]) for j in 1:i]...)))
                                  for i in 1:N]...))
    end
end
````

Although very general and elegant, this seems super wasteful as a bunch of multiplications by 0 will occur and still take runtime. 

````julia
t = TaylorScalar(rand(20)...)
x = rand(10)
@btime Ref(t) .* x; # 922 ns
@btime (TaylorScalar(t.value * xi) for xi in x) # 58 ns
````

and so a specific function would be nice. Same thing occurs for +,-,/ if i read your code correclty. 

As i am not well versed in the @eval shananigans, the code I produced is quite ugly and has non-ncessary loops, but I could not fix that myself ;)

Please tell me what you think, I got a 40% speedup in my application with this. 