### PR TITLE
Change AbstractVector to AbstractArray{T,1}

### DIFF
--- a/src/derivative.jl
+++ b/src/derivative.jl
@@ -19,7 +19,7 @@ function derivative end
 end
 
 @inline function derivative(f, x::V, l::V,
-                            order::Int64) where {V <: AbstractVector{<:Number}}
+    order::Int64) where {V <: AbstractArray{<:Number, 1}}
     derivative(f, x, l, Val{order + 1}())
 end
 
@@ -32,7 +32,7 @@ end
 make_taylor(t0::T, t1::T, ::Val{N}) where {T, N} = TaylorScalar{T, N}(t0, t1)
 
 @inline function derivative(f, x::V, l::V,
-                            vN::Val{N}) where {V <: AbstractVector{<:Number}, N}
+    vN::Val{N}) where {V <: AbstractArray{<:Number, 1}, N}
     t = map((t0, t1) -> make_taylor(t0, t1, vN), x, l) # i.e. map(TaylorScalar{T, N}, x, l)
     return extract_derivative(f(t), N)
 end


### PR DESCRIPTION
Currently, it is not possible to use slices of a matrix in TaylorDiff because this is not of type AbstractVector (see https://discourse.julialang.org/t/speed-up-compilation-with-zygote-and-pinn/99652/4 where a conversion is needed)

This PR changes the type AbstractVector{N} to AbstractArray{T,1}, allowing the use of subvectors.