### PR TITLE
Performance of `(+,-,*,/)(::TaylorScalar,::Number)`: fresh version

### DIFF
--- a/src/primitive.jl
+++ b/src/primitive.jl
@@ -5,20 +5,18 @@ import Base: asin, acos, atan, acot, asec, acsc, asinh, acosh, atanh, acoth, ase
 import Base: sinc, cosc
 import Base: +, -, *, /, \, ^, >, <, >=, <=, ==
 import Base: hypot, max, min
-import Base: zero, one, adjoint, conj, transpose
-
-using Base: tail
+import Base: tail
 
 # Unary
+@inline +(a::Number, b::TaylorScalar) = TaylorScalar((a + value(b)[1]), tail(value(b))...)
+@inline -(a::Number, b::TaylorScalar) = TaylorScalar((a - value(b)[1]), .-tail(value(b))...)
+@inline *(a::Number, b::TaylorScalar) = TaylorScalar((a .* value(b))...)
+@inline /(a::Number, b::TaylorScalar) = /(promote(a, b)...)
 
-@inline zero(::Type{TaylorScalar{T, N}}) where {T, N} = TaylorScalar{T, N}(zero(T))
-@inline one(::Type{TaylorScalar{T, N}}) where {T, N} = TaylorScalar{T, N}(one(T))
-@inline zero(::TaylorScalar{T, N}) where {T, N} = zero(TaylorScalar{T, N})
-@inline one(::TaylorScalar{T, N}) where {T, N} = one(TaylorScalar{T, N})
-
-transpose(t::TaylorScalar) = t
-adjoint(t::TaylorScalar) = t
-conj(t::TaylorScalar) = t
+@inline +(a::TaylorScalar, b::Number) = TaylorScalar((value(a)[1] + b), tail(value(a))...)
+@inline -(a::TaylorScalar, b::Number) = TaylorScalar((value(a)[1] - b), tail(value(a))...)
+@inline *(a::TaylorScalar, b::Number) = TaylorScalar((value(a) .* b)...)
+@inline /(a::TaylorScalar, b::Number) = TaylorScalar((value(a) ./ b)...)
 
 ## Delegated
 

--- a/src/primitive.jl
+++ b/src/primitive.jl
@@ -5,8 +5,20 @@ import Base: asin, acos, atan, acot, asec, acsc, asinh, acosh, atanh, acoth, ase
 import Base: sinc, cosc
 import Base: +, -, *, /, \, ^, >, <, >=, <=, ==
 import Base: hypot, max, min
+import Base: zero, one, adjoint, conj, transpose
+
+using Base: tail
 
 # Unary
+
+@inline zero(::Type{TaylorScalar{T, N}}) where {T, N} = TaylorScalar{T, N}(zero(T))
+@inline one(::Type{TaylorScalar{T, N}}) where {T, N} = TaylorScalar{T, N}(one(T))
+@inline zero(::TaylorScalar{T, N}) where {T, N} = zero(TaylorScalar{T, N})
+@inline one(::TaylorScalar{T, N}) where {T, N} = one(TaylorScalar{T, N})
+
+transpose(t::TaylorScalar) = t
+adjoint(t::TaylorScalar) = t
+conj(t::TaylorScalar) = t
 
 ## Delegated
 
@@ -113,8 +125,12 @@ end
     ex = :($ex; TaylorScalar($([Symbol('v', i) for i in 1:N]...)))
     return :(@inbounds $ex)
 end
-@inline *(a::TaylorScalar{T1, N}, b::TaylorScalar{T2, N}) where {T1,T2,N} = *(promote(a,b)...)
-@inline /(a::TaylorScalar{T1, N}, b::TaylorScalar{T2, N}) where {T1,T2,N} = *(promote(a,b)...)
+@inline function *(a::TaylorScalar{T1, N}, b::TaylorScalar{T2, N}) where {T1, T2, N}
+    *(promote(a, b)...)
+end
+@inline function /(a::TaylorScalar{T1, N}, b::TaylorScalar{T2, N}) where {T1, T2, N}
+    *(promote(a, b)...)
+end
 
 for R in (Integer, Real)
     @eval @generated function ^(t::TaylorScalar{T, N}, n::S) where {S <: $R, T, N}

--- a/src/primitive.jl
+++ b/src/primitive.jl
@@ -123,12 +123,6 @@ end
     ex = :($ex; TaylorScalar($([Symbol('v', i) for i in 1:N]...)))
     return :(@inbounds $ex)
 end
-@inline function *(a::TaylorScalar{T1, N}, b::TaylorScalar{T2, N}) where {T1, T2, N}
-    *(promote(a, b)...)
-end
-@inline function /(a::TaylorScalar{T1, N}, b::TaylorScalar{T2, N}) where {T1, T2, N}
-    *(promote(a, b)...)
-end
 
 for R in (Integer, Real)
     @eval @generated function ^(t::TaylorScalar{T, N}, n::S) where {S <: $R, T, N}

--- a/src/primitive.jl
+++ b/src/primitive.jl
@@ -113,6 +113,8 @@ end
     ex = :($ex; TaylorScalar($([Symbol('v', i) for i in 1:N]...)))
     return :(@inbounds $ex)
 end
+@inline *(a::TaylorScalar{T1, N}, b::TaylorScalar{T2, N}) where {T1,T2,N} = *(promote(a,b)...)
+@inline /(a::TaylorScalar{T1, N}, b::TaylorScalar{T2, N}) where {T1,T2,N} = *(promote(a,b)...)
 
 for R in (Integer, Real)
     @eval @generated function ^(t::TaylorScalar{T, N}, n::S) where {S <: $R, T, N}

--- a/src/scalar.jl
+++ b/src/scalar.jl
@@ -89,10 +89,6 @@ function promote_rule(::Type{TaylorScalar{T, N}},
         ::Type{S}) where {T, S, N}
     TaylorScalar{promote_type(T, S), N}
 end
-function promote_rule(::Type{TaylorScalar{T1, N}},
-                      ::Type{TaylorScalar{T2, N}}) where {T1, T2, N}
-    TaylorScalar{promote_type(T1, T2), N}
-end
 
 function (::Type{F})(x::TaylorScalar{T, N}) where {T, N, F <: AbstractFloat}
     F(primal(x))

--- a/src/scalar.jl
+++ b/src/scalar.jl
@@ -1,5 +1,3 @@
-import Base: zero, one, adjoint, conj, transpose
-import Base: +, -, *, /
 import Base: convert, promote_rule
 
 export TaylorScalar
@@ -89,8 +87,9 @@ function promote_rule(::Type{TaylorScalar{T, N}},
         ::Type{S}) where {T, S, N}
     TaylorScalar{promote_type(T, S), N}
 end
-function promote_rule(::Type{TaylorScalar{T1, N}}, ::Type{TaylorScalar{T2,N}}) where {T1, T2, N}
-TaylorScalar{promote_type(T1,T2), N}
+function promote_rule(::Type{TaylorScalar{T1, N}},
+                      ::Type{TaylorScalar{T2, N}}) where {T1, T2, N}
+    TaylorScalar{promote_type(T1, T2), N}
 end
 
 function (::Type{F})(x::TaylorScalar{T, N}) where {T, N, F <: AbstractFloat}

--- a/src/scalar.jl
+++ b/src/scalar.jl
@@ -1,3 +1,5 @@
+import Base: zero, one, adjoint, conj, transpose
+import Base: +, -, *, /
 import Base: convert, promote_rule
 
 export TaylorScalar

--- a/src/scalar.jl
+++ b/src/scalar.jl
@@ -89,6 +89,9 @@ function promote_rule(::Type{TaylorScalar{T, N}},
         ::Type{S}) where {T, S, N}
     TaylorScalar{promote_type(T, S), N}
 end
+function promote_rule(::Type{TaylorScalar{T1, N}}, ::Type{TaylorScalar{T2,N}}) where {T1, T2, N}
+TaylorScalar{promote_type(T1,T2), N}
+end
 
 function (::Type{F})(x::TaylorScalar{T, N}) where {T, N, F <: AbstractFloat}
     F(primal(x))


### PR DESCRIPTION
Supplants #25 with an updated branch.