### PR TITLE
fix `extract_derivative` when derivative is `0`

### DIFF
--- a/src/primitive.jl
+++ b/src/primitive.jl
@@ -13,7 +13,7 @@ Taylor = Union{TaylorScalar, TaylorArray}
                                                                          $(factorial(P)))
 @inline extract_derivative(a::AbstractArray{<:TaylorScalar}, p) = map(
     t -> extract_derivative(t, p), a)
-@inline extract_derivative(_, p) = false
+@inline extract_derivative(result, p) = zero(result)
 @inline extract_derivative!(result, a::AbstractArray{<:TaylorScalar}, p) = map!(
     t -> extract_derivative(t, p), result, a)
 

--- a/test/derivative.jl
+++ b/test/derivative.jl
@@ -26,6 +26,8 @@ end
 @testset "O-function, I-derivative" begin
     g(x) = x .^ 2
     @test derivative!(zeros(2), g, [1.0, 2.0], [1.0, 0.0], Val(1)) ≈ [2.0, 0.0]
+    gzero(x) = [1.0, 1.0]
+    @test derivative!(zeros(2), gzero, [1.0, 2.0], [1.0, 0.0], Val(1)) == [0.0, 0.0]
 end
 
 @testset "I-function, I-derivative" begin

--- a/test/derivative.jl
+++ b/test/derivative.jl
@@ -27,7 +27,7 @@ end
     g(x) = x .^ 2
     @test derivative!(zeros(2), g, [1.0, 2.0], [1.0, 0.0], Val(1)) ≈ [2.0, 0.0]
     gzero(x) = [1.0, 1.0]
-    @test derivative!(zeros(2), gzero, [1.0, 2.0], [1.0, 0.0], Val(1)) == [0.0, 0.0]
+    @test derivative(gzero, [1.0, 2.0], [1.0, 0.0], Val(1)) == [0.0, 0.0]
 end
 
 @testset "I-function, I-derivative" begin


### PR DESCRIPTION
```
g(x) = [1.0, 2.0]
TaylorDiff.derivative(g, 0.0, Val(1))
```
Before gave `false`, now gives `[0.0, 0.0]`